### PR TITLE
Missing argument.

### DIFF
--- a/src/tau/tau2paje.c
+++ b/src/tau/tau2paje.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 
     /* output build version, date and conversion for aky in the trace */
     aky_dump_version (PROGRAM, argv, argc);
-    poti_header (arguments.basic);
+    poti_header (arguments.basic, 0);
     aky_paje_hierarchy();
     poti_CreateContainer (0, "root", "ROOT", "0", "root");
   }


### PR DESCRIPTION
````
/home/debian/install/akypuera/src/tau/tau2paje.c: In function ‘main’:
/home/debian/install/akypuera/src/tau/tau2paje.c:87:5: error: too few arguments to function ‘poti_header’
     poti_header (arguments.basic);
     ^
In file included from /home/debian/install/akypuera/src/tau/tau2paje.h:24:0,
                 from /home/debian/install/akypuera/src/tau/tau2paje.c:17:
/home/debian/install/akypuera/libpoti/include/poti.h:45:6: note: declared here
 void poti_header (int basic, int old_header);
````

To reproduce, compile with the cmake option `-DTAU=ON`.

Extra argument added to poti_header at 05a62f473856eb13f9cbcfc100c81c0af9836773
aky_converter and otf2 updated with "0" for extra argument (aky_converter at 7c03026dcd894ab743c28dccee7c95d5a8c697c3)
tau was missing the update.
