### PR TITLE
Read buffer size from environment variable

### DIFF
--- a/librastro/include/rastro.h
+++ b/librastro/include/rastro.h
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 1998--2006 Benhur Stein
-    
+
     This file is part of Pajé.
 
     Pajé is free software; you can redistribute it and/or modify it under
@@ -149,7 +149,7 @@ typedef struct {
   int rst_fd;
   char *rst_buffer_ptr;
   char *rst_buffer;
-  int rst_buffer_size;
+  size_t rst_buffer_size;
   u_int64_t id1;
   u_int64_t id2;
 } rst_buffer_t;
@@ -179,7 +179,7 @@ void rst_event_ptr(rst_buffer_t * ptr, u_int16_t type);
 void rst_startevent(rst_buffer_t *ptr, u_int32_t header);
 void rst_endevent(rst_buffer_t * ptr);
 
-/* 
+/*
   Reading Interface
 */
 int rst_open_file(rst_rastro_t *rastro, int buffer_size, char *filename, char *syncfilename);
@@ -188,7 +188,7 @@ void rst_close(rst_rastro_t *rastro);
 void rst_print_event(rst_event_t *event);
 
 /*
- Generate Interface 
+ Generate Interface
 */
 int rst_generate_function_header (char *types, char *header, int header_len);
 int rst_generate_function_implementation (char *types, char *implem, int implem_len);

--- a/librastro/src/rst_write.c
+++ b/librastro/src/rst_write.c
@@ -19,6 +19,7 @@
 */
 #include "rst_private.h"
 #include <stdlib.h>
+#include <errno.h>
 
 #ifndef LIBRASTRO_THREADED
 rst_buffer_t *rst_global_buffer;
@@ -101,13 +102,21 @@ static void __rst_init(rst_buffer_t *ptr,
   ptr->id1 = id1;
   ptr->id2 = id2;
   ptr->write_first_hour = 1;
-  ptr->rst_buffer_size = 100000;
-  if (sscanf(getenv("RST_BUFFER_SIZE"), "%zu", &(ptr->rst_buffer_size)) != 1)
-    fprintf(stderr, "Error reading RST_BUFFER_SIZE, using default value:"\
-        "%zu.\n", ptr->rst_buffer_size);
-  else if (ptr->rst_buffer_size == SIZE_MAX)
-    fprintf(stderr, "RST_BUFFER_SIZE out of range, using maximum value: "\
-        "%zu.\n", SIZE_MAX);
+  char *env = getenv("RST_BUFFER_SIZE");
+  if (env) {
+    errno = 0;
+    /*
+     * Negative values don't trigger errno nor any error value is returned.
+     * They are interpreted as SIZE_MAX - abs(val) + 1
+     */
+    if (sscanf(env, "%zu", &(ptr->rst_buffer_size)) != 1 || errno) {
+      ptr->rst_buffer_size = 100000;
+      fprintf(stderr, "Error %d reading RST_BUFFER_SIZE, using default value:"\
+          "%zu.\n", errno, ptr->rst_buffer_size);
+    }
+  } else {
+    ptr->rst_buffer_size = 100000;
+  }
   ptr->rst_buffer = malloc(ptr->rst_buffer_size);
   bzero(ptr->rst_buffer, ptr->rst_buffer_size);
   RST_RESET(ptr);

--- a/librastro/src/rst_write.c
+++ b/librastro/src/rst_write.c
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 1998--2006 Benhur Stein
-    
+
     This file is part of Pajé.
 
     Pajé is free software; you can redistribute it and/or modify it under
@@ -18,6 +18,7 @@
 	51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 #include "rst_private.h"
+#include <stdlib.h>
 
 #ifndef LIBRASTRO_THREADED
 rst_buffer_t *rst_global_buffer;
@@ -101,6 +102,12 @@ static void __rst_init(rst_buffer_t *ptr,
   ptr->id2 = id2;
   ptr->write_first_hour = 1;
   ptr->rst_buffer_size = 100000;
+  if (sscanf(getenv("RST_BUFFER_SIZE"), "%zu", &(ptr->rst_buffer_size)) != 1)
+    fprintf(stderr, "Error reading RST_BUFFER_SIZE, using default value:"\
+        "%zu.\n", ptr->rst_buffer_size);
+  else if (ptr->rst_buffer_size == SIZE_MAX)
+    fprintf(stderr, "RST_BUFFER_SIZE out of range, using maximum value: "\
+        "%zu.\n", SIZE_MAX);
   ptr->rst_buffer = malloc(ptr->rst_buffer_size);
   bzero(ptr->rst_buffer, ptr->rst_buffer_size);
   RST_RESET(ptr);
@@ -223,7 +230,7 @@ void rst_event_ptr(rst_buffer_t * ptr, u_int16_t type)
 
 /*
  * lls event to be used by rastro itself (for the first event)
- */ 
+ */
 static void rst_event_lls_ptr(rst_buffer_t * ptr, u_int16_t type,
                               u_int64_t l0, u_int64_t l1, char *s0)
 {


### PR DESCRIPTION
Also changes `rst_buffer_size` (from `rst_buffer_t`) from `int` to `size_t` in order to support any value that can be addressed.