### PR TITLE
Warn the user when librastro buffer is flushed to disk

### DIFF
--- a/librastro/src/rst_write.c
+++ b/librastro/src/rst_write.c
@@ -20,6 +20,7 @@
 #include "rst_private.h"
 #include <stdlib.h>
 #include <errno.h>
+#include <stdio.h>
 
 #ifndef LIBRASTRO_THREADED
 rst_buffer_t *rst_global_buffer;
@@ -218,6 +219,9 @@ void rst_endevent(rst_buffer_t * ptr)
 {
     ptr->rst_buffer_ptr = ALIGN_PTR(ptr->rst_buffer_ptr);
     if (RST_BUF_COUNT(ptr) > (RST_BUF_SIZE(ptr) - RST_MAX_EVENT_SIZE)) {
+      fprintf(stderr, "librastro: Buffer size exceeded, flushing to disk. "
+          "Consider using a larger buffer size, defined by the environment "
+          "variable RST_BUFFER_SIZE\n");
         rst_flush(ptr);
     }
 }


### PR DESCRIPTION
Prints the following to stderr when the buffer is flushed to disk due to lack of space:

```
librastro: Buffer size exceeded, flushing to disk. Consider using a larger buffer size, defined by the environment variable RST_BUFFER_SIZE
```

There is a commit before that in which I removed the `timestamp_t` typedef (was `unsigned long long`) and replaced all occurrences accordingly - I think `unsigned long long` is clearer, albeit longer. If that's undesirable I can create a new branch and redo the pull request without that commit.