### PR TITLE
Missing argument

### DIFF
--- a/src/otf/otf2paje.c
+++ b/src/otf/otf2paje.c
@@ -181,7 +181,7 @@ int main (int argc, char **argv)
 
     /* output build version, date and conversion for aky in the trace */
     aky_dump_version (PROGRAM, argv, argc);
-    poti_header (arguments.basic);
+    poti_header (arguments.basic, 0);
     aky_paje_hierarchy();
     poti_CreateContainer (0, "root", "ROOT", "0", "root");
   }


### PR DESCRIPTION
This is the same fix as d0d1eba58a01426da2b970912ea41a25d67fb017, but for `otf2paje` instead of for `otf22paje`.