### PR TITLE
Use a default string lenght across the application

### DIFF
--- a/src/aky/aky_converter.c
+++ b/src/aky/aky_converter.c
@@ -84,8 +84,8 @@ int main(int argc, char **argv)
   double timestamp = -1;
   while (rst_decode_event(&rastro, &event) && !fail) {
     static int root_created = 0;
-    char mpi_process[100];
-    snprintf(mpi_process, 100, "rank%"PRIu64"", event.id1);
+    char mpi_process[AKY_DEFAULT_STR_SIZE];
+    snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%"PRIu64"", event.id1);
     timestamp = event.timestamp;
     switch (event.type) {
     case AKY_PTP_SEND:
@@ -270,8 +270,8 @@ int main(int argc, char **argv)
     case MPI_CART_SUB_IN:
     case MPI_FINALIZE_IN:
       if (!arguments.no_states){
-        char value[100];
-        snprintf(value, 100, "%s", name_get(event.type));
+        char value[AKY_DEFAULT_STR_SIZE];
+        snprintf(value, AKY_DEFAULT_STR_SIZE, "%s", name_get(event.type));
         if (event.ct.n_uint64 == 1){
           /* has message mark */
           int mark = event.v_uint64[0];

--- a/src/aky_aux.c
+++ b/src/aky_aux.c
@@ -20,7 +20,7 @@
 void *aky_ptp_root = NULL;
 
 typedef struct aky {
-  char key[100];
+  char key[AKY_DEFAULT_STR_SIZE];
 } aky_t;
 
 static int aky_compare(const void *a, const void *b)
@@ -35,7 +35,7 @@ void aky_insert(MPI_Request * req)
 {
   aky_t *new;
   new = (aky_t *) calloc(1, sizeof(aky_t));
-  snprintf(new->key, 100, "%p", req);
+  snprintf(new->key, AKY_DEFAULT_STR_SIZE, "%p", req);
   tsearch(new, &aky_ptp_root, aky_compare);
 }
 
@@ -43,7 +43,7 @@ void aky_remove(MPI_Request * req)
 {
   aky_t *new;
   new = (aky_t *) calloc(1, sizeof(aky_t));
-  snprintf(new->key, 100, "%p", req);
+  snprintf(new->key, AKY_DEFAULT_STR_SIZE, "%p", req);
   tdelete(new, &aky_ptp_root, aky_compare);
 }
 
@@ -51,7 +51,7 @@ int aky_check(MPI_Request * req)
 {
   aky_t *new;
   new = (aky_t *) calloc(1, sizeof(aky_t));
-  snprintf(new->key, 100, "%p", req);
+  snprintf(new->key, AKY_DEFAULT_STR_SIZE, "%p", req);
   const void *ret = tfind(new, &aky_ptp_root, aky_compare);
   if (ret) {
     return 1;

--- a/src/aky_keys.c
+++ b/src/aky_keys.c
@@ -50,7 +50,6 @@ static void enqueue(desc_t * desc, elem_t * new)
 {
   if (desc->n == 0){
     /* queue is empty, add in the beginning */
-    desc->n++;
     desc->first = new;
     desc->last = new;
 
@@ -59,7 +58,6 @@ static void enqueue(desc_t * desc, elem_t * new)
     new->tail = NULL;
   }else{
     /* queue is NOT empty, add at the end */
-    desc->n++;
 
     elem_t *old_last = desc->last;
     old_last->tail = new;
@@ -67,6 +65,7 @@ static void enqueue(desc_t * desc, elem_t * new)
     new->tail = NULL;
     desc->last = new;
   }
+  desc->n++;
 }
 
 static elem_t *dequeue(desc_t * desc)

--- a/src/aky_keys.c
+++ b/src/aky_keys.c
@@ -120,7 +120,7 @@ static void free_element(elem_t * elem)
 
 int aky_key_init (void)
 {
-  if (hcreate_r (1000, &hash) == 0){
+  if (hcreate_r (AKY_KEY_TABLE_SIZE, &hash) == 0){
     fprintf (stderr,
              "[aky_keys] at %s,"
              "hash table allocation failed.",
@@ -140,9 +140,9 @@ char *aky_put_key(const char *type, int src, int dst, char *key, int n)
   //zeroe key
   bzero (key, n);
 
-  char aux[100];
-  bzero (aux, 100);
-  snprintf(aux, 100, "%s#%d#%d", type, src, dst);
+  char aux[AKY_DEFAULT_STR_SIZE];
+  bzero (aux, AKY_DEFAULT_STR_SIZE);
+  snprintf(aux, AKY_DEFAULT_STR_SIZE, "%s#%d#%d", type, src, dst);
   ENTRY e, *ep = NULL;
   e.key = aux;
   e.data = NULL;
@@ -170,9 +170,9 @@ char *aky_get_key(const char *type, int src, int dst, char *key, int n)
   bzero (key, n);
 
 
-  char aux[100];
-  bzero (aux, 100);
-  snprintf(aux, 100, "%s#%d#%d", type, src, dst);
+  char aux[AKY_DEFAULT_STR_SIZE];
+  bzero (aux, AKY_DEFAULT_STR_SIZE);
+  snprintf(aux, AKY_DEFAULT_STR_SIZE, "%s#%d#%d", type, src, dst);
   ENTRY e, *ep;
   e.key = aux;
   e.data = NULL;

--- a/src/aky_keys.c
+++ b/src/aky_keys.c
@@ -154,7 +154,10 @@ char *aky_put_key(const char *type, int src, int dst, char *key, int n)
     ((desc_t *) e.data)->first = NULL;
     ((desc_t *) e.data)->last = NULL;
     ((desc_t *) e.data)->n = 0;
-    hsearch_r (e, ENTER, &ep, &hash);
+    if (!hsearch_r (e, ENTER, &ep, &hash)) {
+      perror(__func__);
+      return NULL;
+    }
   }
   elem_t *new = new_element(src, dst, key, n);
   enqueue(ep->data, new);

--- a/src/aky_private.h
+++ b/src/aky_private.h
@@ -46,6 +46,7 @@ char *name_get (u_int16_t id);
 
 #define AKY_DEFAULT_STR_SIZE 200
 #define AKY_INPUT_SIZE 10000
+#define AKY_KEY_TABLE_SIZE 1000
 
 
 #endif //__AKY_PRIVATE_H_

--- a/src/otf/otf2paje_handlers.c
+++ b/src/otf/otf2paje_handlers.c
@@ -33,9 +33,9 @@ static double ticks_to_seconds (unsigned long long ticks)
 
 static void data_def (struct hsearch_data *hash, uint32_t id, const char *name)
 {
-  char key[100];
-  bzero(key, 100);
-  snprintf (key, 100, "%d", id);
+  char key[AKY_DEFAULT_STR_SIZE];
+  bzero(key, AKY_DEFAULT_STR_SIZE);
+  snprintf (key, AKY_DEFAULT_STR_SIZE, "%d", id);
 
   ENTRY e, *ep = NULL;
   e.key = key;
@@ -53,9 +53,9 @@ static char *data_get (struct hsearch_data *hash, uint32_t id)
   /* Find process name */
   char *name = NULL;
   {
-    char key[100];
-    bzero(key, 100);
-    snprintf (key, 100, "%d", id);
+    char key[AKY_DEFAULT_STR_SIZE];
+    bzero(key, AKY_DEFAULT_STR_SIZE);
+    snprintf (key, AKY_DEFAULT_STR_SIZE, "%d", id);
 
     ENTRY e, *ep = NULL;
     e.key = key;
@@ -132,9 +132,9 @@ int handleDefFunction(void *userData, uint32_t stream, uint32_t func,
 		      const char *name, uint32_t funcGroup,
 		      uint32_t source, OTF_KeyValueList * kvlist)
 {
-  char alias[100];
-  bzero(alias, 100);
-  snprintf (alias, 100, "f%d", func);
+  char alias[AKY_DEFAULT_STR_SIZE];
+  bzero(alias, AKY_DEFAULT_STR_SIZE);
+  snprintf (alias, AKY_DEFAULT_STR_SIZE, "f%d", func);
   if (!arguments.dummy && !arguments.no_states){
     poti_DefineEntityValue (alias, "STATE", name, "0 0 0");
   }
@@ -153,9 +153,9 @@ int handleDefCollectiveOperation(void *userData, uint32_t stream,
 				 uint32_t collOp, const char *name,
 				 uint32_t type, OTF_KeyValueList * kvlist)
 {
-  char alias[100];
-  bzero(alias, 100);
-  snprintf (alias, 100, "c%d", collOp);
+  char alias[AKY_DEFAULT_STR_SIZE];
+  bzero(alias, AKY_DEFAULT_STR_SIZE);
+  snprintf (alias, AKY_DEFAULT_STR_SIZE, "c%d", collOp);
   if (!arguments.dummy && !arguments.no_states){
     poti_DefineEntityValue (alias, "STATE", name, "0 0 0");
   }
@@ -298,12 +298,12 @@ int handleEnter(void *userData, uint64_t time, uint32_t function,
 		uint32_t process, uint32_t source,
 		OTF_KeyValueList * kvlist)
 {
-  char palias[100];
-  bzero(palias, 100);
-  snprintf (palias, 100, "p%d", process);
-  char falias[100];
-  bzero(falias, 100);
-  snprintf (falias, 100, "f%d", function);
+  char palias[AKY_DEFAULT_STR_SIZE];
+  bzero(palias, AKY_DEFAULT_STR_SIZE);
+  snprintf (palias, AKY_DEFAULT_STR_SIZE, "p%d", process);
+  char falias[AKY_DEFAULT_STR_SIZE];
+  bzero(falias, AKY_DEFAULT_STR_SIZE);
+  snprintf (falias, AKY_DEFAULT_STR_SIZE, "f%d", function);
   if (!arguments.dummy && !arguments.no_states){
     poti_PushState (ticks_to_seconds(time), palias, "STATE", falias);
   }
@@ -315,9 +315,9 @@ int handleLeave(void *userData, uint64_t time, uint32_t function,
 		uint32_t process, uint32_t source,
 		OTF_KeyValueList * kvlist)
 {
-  char palias[100];
-  bzero(palias, 100);
-  snprintf (palias, 100, "p%d", process);
+  char palias[AKY_DEFAULT_STR_SIZE];
+  bzero(palias, AKY_DEFAULT_STR_SIZE);
+  snprintf (palias, AKY_DEFAULT_STR_SIZE, "p%d", process);
   if (!arguments.dummy && !arguments.no_states){
     poti_PopState (ticks_to_seconds(time), palias, "STATE");
   }
@@ -369,12 +369,12 @@ int handleBeginCollectiveOperation(void *userData, uint64_t time,
 				   uint64_t received, uint32_t scltoken,
 				   OTF_KeyValueList * kvlist)
 {
-  char palias[100];
-  bzero(palias, 100);
-  snprintf (palias, 100, "p%d", process);
-  char calias[100];
-  bzero(calias, 100);
-  snprintf (calias, 100, "c%d", collOp);
+  char palias[AKY_DEFAULT_STR_SIZE];
+  bzero(palias, AKY_DEFAULT_STR_SIZE);
+  snprintf (palias, AKY_DEFAULT_STR_SIZE, "p%d", process);
+  char calias[AKY_DEFAULT_STR_SIZE];
+  bzero(calias, AKY_DEFAULT_STR_SIZE);
+  snprintf (calias, AKY_DEFAULT_STR_SIZE, "c%d", collOp);
   if (!arguments.dummy && !arguments.no_states){
     poti_PushState (ticks_to_seconds(time), palias, "STATE", calias);
   }
@@ -386,9 +386,9 @@ int handleEndCollectiveOperation(void *userData, uint64_t time,
 				 uint32_t process, uint64_t matchingId,
 				 OTF_KeyValueList * kvlist)
 {
-  char palias[100];
-  bzero(palias, 100);
-  snprintf (palias, 100, "p%d", process);
+  char palias[AKY_DEFAULT_STR_SIZE];
+  bzero(palias, AKY_DEFAULT_STR_SIZE);
+  snprintf (palias, AKY_DEFAULT_STR_SIZE, "p%d", process);
   if (!arguments.dummy && !arguments.no_states){
     poti_PopState (ticks_to_seconds(time), palias, "STATE");
   }
@@ -408,9 +408,9 @@ int handleBeginProcess(void *userData, uint64_t time, uint32_t process,
 {
   char *name = data_get(&process_name_hash, process);
   if (name){
-    char alias[100];
-    bzero(alias, 100);
-    snprintf (alias, 100, "p%d", process);
+    char alias[AKY_DEFAULT_STR_SIZE];
+    bzero(alias, AKY_DEFAULT_STR_SIZE);
+    snprintf (alias, AKY_DEFAULT_STR_SIZE, "p%d", process);
     if (!arguments.dummy){
       poti_CreateContainer (ticks_to_seconds(time), alias, "PROCESS", "root", name); 
     }
@@ -424,9 +424,9 @@ int handleEndProcess(void *userData, uint64_t time, uint32_t process,
 {
   char *name = data_get(&process_name_hash, process);
   if (name){
-    char alias[100];
-    bzero(alias, 100);
-    snprintf (alias, 100, "p%d", process);
+    char alias[AKY_DEFAULT_STR_SIZE];
+    bzero(alias, AKY_DEFAULT_STR_SIZE);
+    snprintf (alias, AKY_DEFAULT_STR_SIZE, "p%d", process);
     if (!arguments.dummy){
       poti_DestroyContainer (ticks_to_seconds(time), "PROCESS", alias);
     }

--- a/src/otf2/otf22paje.c
+++ b/src/otf2/otf22paje.c
@@ -162,8 +162,8 @@ int main (int argc, char **argv)
   }
 
   for (i = 0; i < num_locations; i++){
-    char mpi_process[100];
-    snprintf(mpi_process, 100, "rank%zu", i);
+    char mpi_process[AKY_DEFAULT_STR_SIZE];
+    snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%zu", i);
     if (!arguments.dummy){
       poti_DestroyContainer(user_data->last_timestamp, "P", mpi_process);
     }

--- a/src/otf2/otf22paje_handlers.c
+++ b/src/otf2/otf22paje_handlers.c
@@ -79,8 +79,8 @@ OTF2_CallbackCode otf22paje_global_def_location_group_flat (void *userData, OTF2
 {
   const char *name_str = string_hash[name];
 
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", (int)self);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", (int)self);
   if (!arguments.dummy){
     nf_container_type_declare ("P", "0");
     nf_state_type_declare ("STATE", "P");
@@ -109,8 +109,8 @@ OTF2_CallbackCode otf22paje_global_def_location_group_hostfile (void *userData, 
     }
   }
 
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", (int)self);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", (int)self);
   if (!arguments.dummy){
     nf_container_type_declare ("P", "H");
     nf_state_type_declare ("STATE", "P");
@@ -148,8 +148,8 @@ OTF2_CallbackCode otf22paje_global_def_location_group (void *userData, OTF2_Loca
   int p = (int)systemTreeParent;
   const char *container = container_tree_hash[p];
 
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", (int)self);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", (int)self);
   if (!arguments.dummy){
     poti_CreateContainer(0, mpi_process, newTypeName, container, name_str);
   }
@@ -256,8 +256,8 @@ OTF2_CallbackCode otf22paje_enter (OTF2_LocationRef locationID, OTF2_TimeStamp t
     return OTF2_CALLBACK_SUCCESS;
   }
 
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%"PRId64"", locationID);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%"PRId64"", locationID);
   if (!arguments.dummy && !arguments.no_states){
     poti_PushState(time_to_seconds(time, data->time_resolution),
                    mpi_process, "STATE", state_name);
@@ -275,8 +275,8 @@ OTF2_CallbackCode otf22paje_leave (OTF2_LocationRef locationID, OTF2_TimeStamp t
     return OTF2_CALLBACK_SUCCESS;
   }
 
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%"PRId64"", locationID);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%"PRId64"", locationID);
   if (!arguments.dummy && !arguments.no_states){
     poti_PopState(time_to_seconds(time, data->time_resolution),
                   mpi_process, "STATE");

--- a/src/otf2/otf22paje_hostfile.c
+++ b/src/otf2/otf22paje_hostfile.c
@@ -178,15 +178,15 @@ int nf_read_and_create_hierarchy (char *filename)
       }
       char *new_container = hierarchy[j];
 
-      char new_container_type[100];
+      char new_container_type[AKY_DEFAULT_STR_SIZE];
       {
 	//type
-	snprintf (new_container_type, 100, "L%d", j);
+	snprintf (new_container_type, AKY_DEFAULT_STR_SIZE, "L%d", j);
 	if (j+1 == depth){
 	  nf_container_type_declare (new_container_type, NULL);
 	}else{
-	  char container_type[100];
-	  snprintf (container_type, 100, "L%d", j+1);
+	  char container_type[AKY_DEFAULT_STR_SIZE];
+	  snprintf (container_type, AKY_DEFAULT_STR_SIZE, "L%d", j+1);
 	  nf_container_type_declare (new_container_type, container_type);
 	}
       }
@@ -222,12 +222,12 @@ int nf_read_and_create_hierarchy (char *filename)
 
     //create things (cluster)
     for (j = 0; j < 1; j++){
-      char new_container_type[100];
+      char new_container_type[AKY_DEFAULT_STR_SIZE];
       {
-	char container_type[100];
+	char container_type[AKY_DEFAULT_STR_SIZE];
 	//type
-	snprintf (new_container_type, 100, "L%d", j);
-	snprintf (container_type, 100, "L%d", j+1);
+	snprintf (new_container_type, AKY_DEFAULT_STR_SIZE, "L%d", j);
+	snprintf (container_type, AKY_DEFAULT_STR_SIZE, "L%d", j+1);
 	nf_container_type_declare (new_container_type, container_type);
       }
       {

--- a/src/tau/tau2paje_handlers.c
+++ b/src/tau/tau2paje_handlers.c
@@ -40,9 +40,9 @@ int EnterState(void *userData, double time,
   /* Find state name */
   char *state_name = NULL;
   {
-    char state_key[100];
-    bzero(state_key, 100);
-    snprintf (state_key, 100, "%d", stateid);
+    char state_key[AKY_DEFAULT_STR_SIZE];
+    bzero(state_key, AKY_DEFAULT_STR_SIZE);
+    snprintf (state_key, AKY_DEFAULT_STR_SIZE, "%d", stateid);
 
     ENTRY e, *ep = NULL;
     e.key = state_key;
@@ -73,8 +73,8 @@ int EnterState(void *userData, double time,
   }
 
   rank_last_time[nodeid] = time_to_seconds(time);
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", nodeid);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", nodeid);
 
   if (!arguments.dummy && !arguments.no_states){
     poti_PushState(rank_last_time[nodeid], mpi_process, "STATE", state_name);
@@ -89,9 +89,9 @@ int LeaveState(void *userData, double time, unsigned int nodeid,
   /* Find state name */
   char *state_name = NULL;
   {
-    char state_key[100];
-    bzero(state_key, 100);
-    snprintf (state_key, 100, "%d", stateid);
+    char state_key[AKY_DEFAULT_STR_SIZE];
+    bzero(state_key, AKY_DEFAULT_STR_SIZE);
+    snprintf (state_key, AKY_DEFAULT_STR_SIZE, "%d", stateid);
 
     ENTRY e, *ep = NULL;
     e.key = state_key;
@@ -108,8 +108,8 @@ int LeaveState(void *userData, double time, unsigned int nodeid,
     return 0;
   }
   rank_last_time[nodeid] = time_to_seconds(time);
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", nodeid);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", nodeid);
   if (!arguments.dummy && !arguments.no_states){
     poti_PopState(rank_last_time[nodeid], mpi_process, "STATE");
   }
@@ -127,8 +127,8 @@ int ClockPeriod(void *userData, double clkPeriod)
 int DefThread(void *userData, unsigned int nodeid,
               unsigned int threadToken, const char *threadName)
 {
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", nodeid);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", nodeid);
   if (!arguments.dummy){
     poti_CreateContainer(0, mpi_process, "PROCESS", "root", mpi_process);
   }
@@ -143,8 +143,8 @@ int DefThread(void *userData, unsigned int nodeid,
 
 int EndTrace(void *userData, unsigned int nodeid, unsigned int threadid)
 {
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", nodeid);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", nodeid);
   if (!arguments.dummy){
     poti_DestroyContainer(rank_last_time[nodeid], "PROCESS", mpi_process);
   }
@@ -165,9 +165,9 @@ int DefState(void *userData, unsigned int stateid, const char *statename,
     return 0;
   }
 
-  char state_key[100];
-  bzero(state_key, 100);
-  snprintf (state_key, 100, "%d", stateid);
+  char state_key[AKY_DEFAULT_STR_SIZE];
+  bzero(state_key, AKY_DEFAULT_STR_SIZE);
+  snprintf (state_key, AKY_DEFAULT_STR_SIZE, "%d", stateid);
 
   ENTRY e, *ep = NULL;
   e.key = state_key;
@@ -216,8 +216,8 @@ int SendMessage(void *userData,
               AKY_DEFAULT_STR_SIZE);
   rank_last_time[sourceNodeToken] = time_to_seconds(time);
   rank_last_time[destinationNodeToken] = time_to_seconds(time);
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", sourceNodeToken);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", sourceNodeToken);
   if (!arguments.dummy){
     poti_StartLinkSizeMark(rank_last_time[sourceNodeToken], "root", "LINK",
                            mpi_process, "PTP", key, messageSize, messageTag);
@@ -262,8 +262,8 @@ int RecvMessage(void *userData, double time,
   }
   rank_last_time[sourceNodeToken] = time_to_seconds(time);
   rank_last_time[destinationNodeToken] = time_to_seconds(time);
-  char mpi_process[100];
-  snprintf(mpi_process, 100, "rank%d", destinationNodeToken);
+  char mpi_process[AKY_DEFAULT_STR_SIZE];
+  snprintf(mpi_process, AKY_DEFAULT_STR_SIZE, "rank%d", destinationNodeToken);
   if (!arguments.dummy){
     poti_EndLink(rank_last_time[destinationNodeToken], "root", "LINK",
                 mpi_process, "PTP", key);


### PR DESCRIPTION
aky keys are strings of hardcoded length, sometimes they're 100 bytes long, sometimes they're `AKY_DEFAULT_STR_SIZE` (200) bytes long. Other strings (such as hostnames) also have hardcoded lengths. This commit changes all string sizes from 100 to `AKY_DEFAULT_STR_SIZE` across the entire application. Notice that `AKY_DEFAULT_STR_SIZE` was introduced in f12f6058cd8c42ab421f43ad26808a3bb686f4c9, but some string introduced after that commit seem to use 100 instead nevertheless (e.g. f74819b60a774a99a40b37fc5ce89f147dadece0), so I'm not sure if this change is desirable. 

Notice also that this change only affects aky strings, since `AKY_DEFAULT_STR_SIZE` is defined on `aky_private.h`. Librastro still uses hardcoded lengths:

````
$ ~/svn/akypuera grep -r . -Pe '\[\d\d+\]'
./librastro/src/timesync/rst_timesync.c:  char str[10];
./librastro/src/generate/rst_generate.c:      char read_str[100];
./librastro/src/rst_read.c:  char field_types[100];
./librastro/src/rst_write.c:  char fname[30];
./src/otf2-omp-print/otf2ompprint2paje.pl:          $line =~ s/:([1234567890])/_\1/g;
````

There are also two minor fixes to `aky_keys.c`.