### PR TITLE
Implements MPI_Scatter and collective communication links

### DIFF
--- a/include/aky.h
+++ b/include/aky.h
@@ -308,5 +308,7 @@
 //aky stuff
 #define AKY_PTP_SEND 5000
 #define AKY_PTP_RECV 5001
+#define AKY_1TN_SEND 5002
+#define AKY_1TN_RECV 5003
 
 #endif //__AKY_H

--- a/src/aky.c
+++ b/src/aky.c
@@ -242,10 +242,28 @@ MPI_Datatype recvtype;
 int root;
 MPI_Comm comm;
 {
-  rst_event(MPI_SCATTER_IN);
+  int rank;
+  PMPI_Comm_rank(comm, &rank);
+  if (rank == root) {
+    // TODO should the send mark be the same as that of PTP comms?
+    rst_event_l(MPI_SCATTER_IN, send_mark);
+    /*
+     * The semantics are a tad different from the ptp comms: We register the
+     * communicator size instead of the recv rank. This is useful for
+     * aky_converter.
+     */
+    int size;
+    PMPI_Comm_size(comm, &size);
+    rst_event_iil(AKY_1TN_SEND, size, sendcnt, send_mark);
+    send_mark++;
+  } else {
+    rst_event(MPI_SCATTER_IN);
+  }
   int returnVal =
-      PMPI_Scatter(sendbuf, sendcnt, sendtype, recvbuf, recvcnt,
-                   recvtype, root, comm);
+    PMPI_Scatter(sendbuf, sendcnt, sendtype, recvbuf, recvcnt,
+        recvtype, root, comm);
+  if (rank != root)
+    rst_event_i(AKY_1TN_RECV, AKY_translate_rank(comm, root));
   rst_event(MPI_SCATTER_OUT);
   return returnVal;
 }

--- a/src/aky/aky_converter.c
+++ b/src/aky/aky_converter.c
@@ -131,6 +131,52 @@ int main(int argc, char **argv)
         poti_EndLink(timestamp, "root", "LINK", mpi_process, "PTP", key);
       }
       break;
+    case AKY_1TN_SEND:
+      if (!arguments.no_links) {
+        char key[AKY_DEFAULT_STR_SIZE];
+        int messageSize = -1;
+        int mark = -1;
+        if (event.ct.n_uint32 == 2){
+          messageSize = event.v_uint32[1];
+          if (event.ct.n_uint64 == 1)
+            mark = event.v_uint64[0];
+        }
+        u_int32_t rank;
+        for (rank = 0; rank < event.v_uint32[0]; rank++) {
+        /*                        ^ number of processes in the communicator */
+          // TODO register a link to self also?
+          if (rank != event.id1) {
+            aky_put_key(AKY_KEY_1TN, event.id1, rank, key, AKY_DEFAULT_STR_SIZE);
+                /*                   ^ our rank ^ dst */
+            if (messageSize != -1 && mark != -1)
+              poti_StartLinkSizeMark(timestamp, "root", "LINK", mpi_process,
+                  "1TN", key, messageSize, mark);
+            else
+              poti_StartLink(timestamp, "root", "LINK", mpi_process, "1TN",
+                  key);
+          }
+        }
+      }
+      break;
+    case AKY_1TN_RECV:
+      if (!arguments.no_links) {
+        char key[AKY_DEFAULT_STR_SIZE];
+        char *result = aky_get_key(AKY_KEY_1TN, event.v_uint32[0], event.id1,
+            key, AKY_DEFAULT_STR_SIZE);
+            /*                                  ^ src              ^ rank */
+        if (!result) {
+          fprintf (stderr,
+                   "[aky_converter] at %s, no key to generate a pajeEndLink,\n"
+                   "[aky_converter] got a receive at dst = %"PRIu64" from src = %d\n"
+                   "[aky_converter] but no send for this receive yet,\n"
+                   "[aky_converter] do you synchronize your input traces?\n",
+                   __FUNCTION__, event.id1, event.v_uint32[0]);
+          if (!arguments.ignore_errors)
+            fail = 1;
+        }
+        poti_EndLink(timestamp, "root", "LINK", mpi_process, "1TN", key);
+      }
+      break;
     case MPI_INIT:
       if (root_created == 0){
         poti_CreateContainer (timestamp, "root", "ROOT", "0", "root");

--- a/src/aky/aky_converter.c
+++ b/src/aky/aky_converter.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
             mark = event.v_uint64[0];
           }
         }
-        aky_put_key("n", event.id1, event.v_uint32[0], key,
+        aky_put_key(AKY_KEY_PTP, event.id1, event.v_uint32[0], key,
                     AKY_DEFAULT_STR_SIZE);
         if (messageSize != -1 && mark != -1){
           poti_StartLinkSizeMark(timestamp, "root", "LINK",
@@ -115,8 +115,8 @@ int main(int argc, char **argv)
     case AKY_PTP_RECV:
       if (!arguments.no_links){
         char key[AKY_DEFAULT_STR_SIZE];
-        char *result = aky_get_key("n", event.v_uint32[0], event.id1, key,
-            AKY_DEFAULT_STR_SIZE);
+        char *result = aky_get_key(AKY_KEY_PTP, event.v_uint32[0], event.id1,
+            key, AKY_DEFAULT_STR_SIZE);
         if (result == NULL){
           fprintf (stderr,
                    "[aky_converter] at %s, no key to generate a pajeEndLink,\n"

--- a/src/aky_private.h
+++ b/src/aky_private.h
@@ -48,6 +48,6 @@ char *name_get (u_int16_t id);
 #define AKY_INPUT_SIZE 10000
 #define AKY_KEY_TABLE_SIZE 1000
 #define AKY_KEY_PTP "ptp"
-
+#define AKY_KEY_1TN "1tn"
 
 #endif //__AKY_PRIVATE_H_

--- a/src/aky_private.h
+++ b/src/aky_private.h
@@ -47,6 +47,7 @@ char *name_get (u_int16_t id);
 #define AKY_DEFAULT_STR_SIZE 200
 #define AKY_INPUT_SIZE 10000
 #define AKY_KEY_TABLE_SIZE 1000
+#define AKY_KEY_PTP "ptp"
 
 
 #endif //__AKY_PRIVATE_H_


### PR DESCRIPTION
This implements `MPI_Scatter` properly, registering the communication instead of just registering it as a local (non-communication) event. I.e. it registers links for the collective communication. The semantics is just a bit different from PTP links - instead of registering the destination rank at the 1TN send, the number of processes in the communicator (to which the send sends) is registered. At the 1TN recv the semantics are the same as for PTP recvs. The recv at the root rank (at the sender) is not registered.

PS: This pulls in another commit which changes the aky key type string for PTP communications from `"n"` to `"ptp"`, and introduces the aky key type for 1TN communications (`"1tn"`).

PPS: Here's a visual comparison of the difference (these are two different traces, the scatter from rank1 happened a bit later on the old case):

![scatter](https://cloud.githubusercontent.com/assets/3854807/19692364/76b1e072-9ab6-11e6-8bbc-2a3a477e21f4.png)
